### PR TITLE
fix: use `BigInt` constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ const _privateNegate = privateKey => {
 const _pointAddScalar = (p, tweak, isCompressed) => {
   const P = necc.Point.fromHex(p);
   const t = normalizeScalar(tweak);
-  const Q = necc.Point.BASE.multiplyAndAddUnsafe(P, t, 1n);
+  const Q = necc.Point.BASE.multiplyAndAddUnsafe(P, t, BigInt(1));
   if (!Q) throw new Error('Tweaked point at infinity');
   return Q.toRawBytes(isCompressed);
 };


### PR DESCRIPTION
Fixes an issue in our environment when Webpack doesn't work with `_n` syntax.

### Tested

Unit tests pass